### PR TITLE
Round scraped numeric values to two decimal places

### DIFF
--- a/divifilter_data_updater/helper_functions.py
+++ b/divifilter_data_updater/helper_functions.py
@@ -66,7 +66,6 @@ def clean_numeric_value(value):
         return None
 
     try:
-        # Try to convert to float
-        return float(cleaned)
+        return round(float(cleaned), 2)
     except (ValueError, AttributeError):
         return None

--- a/divifilter_data_updater/yahoo_finance.py
+++ b/divifilter_data_updater/yahoo_finance.py
@@ -61,10 +61,15 @@ def get_yahoo_finance_data_for_tickers_tuple(tickers_tuple: tuple) -> tuple[date
             
             # Clean numeric values
             if wanted_stock_key in filtered_radar_dict[stock_ticker]:
-                filtered_radar_dict[stock_ticker][wanted_stock_key] = clean_numeric_value(filtered_radar_dict[stock_ticker][wanted_stock_key])
-                # Yahoo returns payoutRatio as a fraction (0.65); drip scrape stores it as a percent (65.0). Normalize to percent.
-                if wanted_stock_key == "Payout Ratio" and filtered_radar_dict[stock_ticker][wanted_stock_key] is not None:
-                    filtered_radar_dict[stock_ticker][wanted_stock_key] *= 100
+                raw_value = filtered_radar_dict[stock_ticker][wanted_stock_key]
+                # Yahoo returns payoutRatio as a fraction (0.65); drip scrape stores it as a percent (65.0).
+                # Normalize to percent before cleaning so rounding preserves precision.
+                if wanted_stock_key == "Payout Ratio" and raw_value is not None:
+                    try:
+                        raw_value = float(raw_value) * 100
+                    except (ValueError, TypeError):
+                        pass
+                filtered_radar_dict[stock_ticker][wanted_stock_key] = clean_numeric_value(raw_value)
     yahoo_finance_query_date_time = datetime.now(timezone.utc)
     return yahoo_finance_query_date_time, filtered_radar_dict
 

--- a/test/test_helper_functions.py
+++ b/test/test_helper_functions.py
@@ -38,6 +38,14 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertIsNone(clean_numeric_value("abc"))
         self.assertIsNone(clean_numeric_value("1.2.3"))
 
+    def test_clean_numeric_value_rounds_to_two_decimals(self):
+        self.assertEqual(clean_numeric_value("123.456"), 123.46)
+        self.assertEqual(clean_numeric_value("123.454"), 123.45)
+        self.assertEqual(clean_numeric_value("1,234.5678"), 1234.57)
+        self.assertEqual(clean_numeric_value(123.456789), 123.46)
+        self.assertEqual(clean_numeric_value("$99.999"), 100.0)
+        self.assertEqual(clean_numeric_value("5.678%"), 5.68)
+
 class TestRadarDictToTable(unittest.TestCase):
 
     def test_multi_ticker_dict(self):

--- a/test/test_yahoo_finance.py
+++ b/test/test_yahoo_finance.py
@@ -82,6 +82,25 @@ class TestYahooFinance(unittest.TestCase):
         self.assertEqual(reply["PG"]["Price"], 150.0)
         self.assertEqual(reply["SCL"]["Price"], 75.0)
 
+    @patch('divifilter_data_updater.yahoo_finance.yf.Tickers')
+    def test_payout_ratio_preserves_precision(self, mock_tickers):
+        # Yahoo returns payoutRatio as a fraction; we need the *100 conversion
+        # to happen before rounding so 0.6523 becomes 65.23, not 65.0.
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            'currentPrice': 10.0,
+            'fiftyTwoWeekLow': 5.0,
+            'fiftyTwoWeekHigh': 15.0,
+            'priceToBook': 1.0,
+            'payoutRatio': 0.6523,
+        }
+        mock_tickers_instance = MagicMock()
+        mock_tickers_instance.tickers = {'PG': mock_ticker}
+        mock_tickers.return_value = mock_tickers_instance
+
+        _, reply = get_yahoo_finance_data_for_tickers_tuple(("PG",))
+        self.assertEqual(reply["PG"]["Payout Ratio"], 65.23)
+
     def test_disable_yahoo_logs(self):
         # Test that disable_yahoo_logs doesn't raise an error
         disable_yahoo_logs()


### PR DESCRIPTION
Centralize the rounding in clean_numeric_value so every Float column written to dividend_data_table is stored with consistent 2-decimal precision. Reorder the Yahoo Payout Ratio *100 conversion to run before the cleaning step so the round trip preserves hundredths (e.g. 0.6523 -> 65.23 rather than 65.0).

Fixes #

## Proposed Changes

  -
  -
  -
